### PR TITLE
Fix: Add if(IsOnFloor()) {motion.Y = 0)} to HandleJumping so that gra…

### DIFF
--- a/player.cs
+++ b/player.cs
@@ -85,6 +85,11 @@ public partial class player : CharacterBody2D
         // Ceiling for motion.Y * JumpForce
         int jumpCeil = -1050;
 
+        if (IsOnFloor())
+        {
+            motion.Y = 0;
+        }
+
         // If not jumping currently
         if (!isJumping)
         {


### PR DESCRIPTION
…vity doesn't build up forever while grounded and not jumping.